### PR TITLE
fast-note PHP-FPM app

### DIFF
--- a/.github/workflows/fast-note.yml
+++ b/.github/workflows/fast-note.yml
@@ -2,7 +2,6 @@ name: fast-note
 
 on:
   push:
-    branches: [main]
     paths:
       - 'fast-note/**'
   pull_request:
@@ -36,8 +35,10 @@ jobs:
         run: |
           docker build -t ghcr.io/${{ github.repository_owner }}/fast-note:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha }} fast-note
       - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Push image
+        if: github.ref == 'refs/heads/main'
         run: |
           docker push ghcr.io/${{ github.repository_owner }}/fast-note:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha }}

--- a/.github/workflows/fast-note.yml
+++ b/.github/workflows/fast-note.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
-        run: php fast-note/tests/basic.php
+        run: |
+          php -l fast-note/index.php
+          php fast-note/tests/basic.php
 
   build:
     if: github.event_name == 'push'

--- a/.github/workflows/fast-note.yml
+++ b/.github/workflows/fast-note.yml
@@ -1,0 +1,43 @@
+name: fast-note
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'fast-note/**'
+  pull_request:
+    paths:
+      - 'fast-note/**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: php fast-note/tests/basic.php
+
+  build:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set build vars
+        id: vars
+        run: |
+          echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Build image
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/fast-note:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha }} fast-note
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/fast-note:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha }}

--- a/fast-note/.gitignore
+++ b/fast-note/.gitignore
@@ -1,0 +1,1 @@
+notes.sqlite

--- a/fast-note/Dockerfile
+++ b/fast-note/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:8.3-fpm
+WORKDIR /var/www/html
+COPY . /var/www/html
+RUN chown -R www-data:www-data /var/www/html
+EXPOSE 9000

--- a/fast-note/README.md
+++ b/fast-note/README.md
@@ -1,0 +1,40 @@
+# Fast Note
+
+Fast Note is a tiny PHP web application for quickly sharing text snippets.
+All notes are stored in a SQLite database and identified by a simple `note`
+query parameter. No authentication is provided.
+
+## Motivation and design trade-offs
+
+Fast Note targets small, trusted networks where a quick shared scratch pad is useful.
+To stay lightweight it intentionally omits user accounts, authentication and third-party
+libraries. Anyone with access can read or overwrite any note and everything is persisted
+in a single SQLite file.
+
+## Running with Docker
+
+```bash
+# Build image
+docker build -t fast-note .
+
+# Run PHP-FPM container with persistent storage
+touch notes.sqlite
+docker run -p 9000:9000 -v $(pwd)/notes.sqlite:/var/www/html/notes.sqlite --name fast-note fast-note
+```
+
+This image only provides PHP-FPM. Pair it with a web server such as Nginx or
+Caddy and proxy requests to `fast-note:9000`.
+
+The application stores notes in `notes.sqlite`. The volume mount above ensures
+the database survives container restarts.
+
+### Configuration
+
+Set the `FASTNOTE_DB` environment variable to override the database location
+or to use special modes, for example:
+
+```bash
+FASTNOTE_DB="file:memdb1?mode=memory&cache=shared" php -S localhost:8000
+```
+
+This can be useful for ephemeral or test environments.

--- a/fast-note/index.php
+++ b/fast-note/index.php
@@ -1,0 +1,58 @@
+<?php
+// Fast Note - simple shared text pad
+
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
+$dbPath = getenv('FASTNOTE_DB') ?: __DIR__ . '/notes.sqlite';
+if (!isset($GLOBALS['db'])) {
+    $GLOBALS['db'] = new SQLite3($dbPath);
+    $GLOBALS['db']->exec('CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, content TEXT)');
+}
+$db = $GLOBALS['db'];
+
+$id = $_GET['note'] ?? 'home';
+if (!preg_match('/^[A-Za-z0-9_-]+$/', $id)) {
+    http_response_code(400);
+    echo 'Invalid note id';
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $content = $_POST['content'] ?? '';
+    $stmt = $db->prepare('REPLACE INTO notes (id, content) VALUES (:id, :content)');
+    $stmt->bindValue(':id', $id, SQLITE3_TEXT);
+    $stmt->bindValue(':content', $content, SQLITE3_TEXT);
+    $stmt->execute();
+    $saved = true;
+}
+
+$stmt = $db->prepare('SELECT content FROM notes WHERE id = :id');
+$stmt->bindValue(':id', $id, SQLITE3_TEXT);
+$result = $stmt->execute();
+$row = $result->fetchArray(SQLITE3_ASSOC);
+$content = $row['content'] ?? '';
+?>
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Fast Note - <?php echo htmlspecialchars($id, ENT_QUOTES); ?></title>
+    <style>
+        textarea { width:100%; height:90vh; font-family: monospace; }
+        body { margin:0; }
+        form { height:100%; }
+        .notice { position: fixed; top:10px; right:10px; color: green; }
+        button { position: fixed; top:10px; right:10px; }
+    </style>
+</head>
+<body>
+    <?php if (!empty($saved)): ?>
+        <div class="notice">Saved!</div>
+    <?php endif; ?>
+    <form method="post">
+        <textarea name="content"><?php echo htmlspecialchars($content, ENT_QUOTES); ?></textarea>
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/fast-note/tests/basic.php
+++ b/fast-note/tests/basic.php
@@ -1,0 +1,25 @@
+<?php
+$GLOBALS['db'] = new SQLite3(':memory:');
+$GLOBALS['db']->exec('CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, content TEXT)');
+
+// First request: save note
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_GET['note'] = 'test';
+$_POST['content'] = 'hello';
+ob_start();
+include __DIR__ . '/../index.php';
+ob_end_clean();
+
+// Second request: read note back
+$_SERVER['REQUEST_METHOD'] = 'GET';
+$_POST = [];
+ob_start();
+include __DIR__ . '/../index.php';
+$out = ob_get_clean();
+
+if (strpos($out, 'hello') === false) {
+    throw new Exception('content mismatch');
+}
+
+echo "basic test passed\n";
+


### PR DESCRIPTION
## Summary
- document motivation and add volume-mounted Docker example for persistent SQLite storage
- add a basic SQLite test and GitHub Actions workflow to run it
- build and push image to GHCR on main push tagged with date and short sha
- exercise index.php via in-memory integration test

## Testing
- `php -l fast-note/index.php`
- `php fast-note/tests/basic.php`


------
https://chatgpt.com/codex/tasks/task_e_68b44f7a615883239e6f0a418b19d22f