### PR TITLE
Switch from PHP-FPM to Apache for simpler deployment

### DIFF
--- a/fast-note/Dockerfile
+++ b/fast-note/Dockerfile
@@ -1,5 +1,7 @@
-FROM php:8.3-fpm
+FROM php:8.3-apache
 WORKDIR /var/www/html
 COPY . /var/www/html
 RUN chown -R www-data:www-data /var/www/html
-EXPOSE 9000
+RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
+RUN sed -i 's/:80>/:8080>/' /etc/apache2/sites-available/000-default.conf
+EXPOSE 8080

--- a/fast-note/README.md
+++ b/fast-note/README.md
@@ -17,13 +17,12 @@ in a single SQLite file.
 # Build image
 docker build -t fast-note .
 
-# Run PHP-FPM container with persistent storage
+# Run container with persistent storage
 touch notes.sqlite
-docker run -p 9000:9000 -v $(pwd)/notes.sqlite:/var/www/html/notes.sqlite --name fast-note fast-note
+docker run -p 8080:8080 -v $(pwd)/notes.sqlite:/var/www/html/notes.sqlite --name fast-note fast-note
 ```
 
-This image only provides PHP-FPM. Pair it with a web server such as Nginx or
-Caddy and proxy requests to `fast-note:9000`.
+The application runs on port 8080 and includes Apache web server.
 
 The application stores notes in `notes.sqlite`. The volume mount above ensures
 the database survives container restarts.


### PR DESCRIPTION
- Change base image from php:8.3-fpm to php:8.3-apache
- Configure Apache to listen on port 8080 instead of 80
- Update README to reflect new port and simplified setup
- Eliminates need for separate web server container

🤖 Generated with [Claude Code](https://claude.ai/code)