### PR TITLE
Fix SQLite permissions by mounting data directory

### DIFF
--- a/fast-note/Dockerfile
+++ b/fast-note/Dockerfile
@@ -4,4 +4,7 @@ COPY . /var/www/html
 RUN chown -R www-data:www-data /var/www/html
 RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 RUN sed -i 's/:80>/:8080>/' /etc/apache2/sites-available/000-default.conf
+# Create data directory for SQLite database
+RUN mkdir -p /var/www/html/data && chown www-data:www-data /var/www/html/data
+ENV FASTNOTE_DB=/var/www/html/data/notes.sqlite
 EXPOSE 8080

--- a/fast-note/README.md
+++ b/fast-note/README.md
@@ -18,13 +18,13 @@ in a single SQLite file.
 docker build -t fast-note .
 
 # Run container with persistent storage
-touch notes.sqlite
-docker run -p 8080:8080 -v $(pwd)/notes.sqlite:/var/www/html/notes.sqlite --name fast-note fast-note
+mkdir -p data
+docker run -p 8080:8080 -v $(pwd)/data:/var/www/html/data --name fast-note fast-note
 ```
 
 The application runs on port 8080 and includes Apache web server.
 
-The application stores notes in `notes.sqlite`. The volume mount above ensures
+The application stores notes in `data/notes.sqlite`. The volume mount above ensures
 the database survives container restarts.
 
 ### Configuration


### PR DESCRIPTION
- Mount data directory instead of SQLite file directly
- Set FASTNOTE_DB env var to point to data/notes.sqlite
- Create data directory with proper www-data ownership in container
- Update README with new volume mount approach
- Resolves readonly database permission issues

🤖 Generated with [Claude Code](https://claude.ai/code)