### PR TITLE
Add health status endpoint

### DIFF
--- a/fast-note/README.md
+++ b/fast-note/README.md
@@ -4,6 +4,11 @@ Fast Note is a tiny PHP web application for quickly sharing text snippets.
 All notes are stored in a SQLite database and identified by a simple `note`
 query parameter. No authentication is provided.
 
+## Status endpoint
+
+Fast Note exposes a health check at `/status` which runs a simple database
+query and responds with `ok` when the service is healthy.
+
 ## Motivation and design trade-offs
 
 Fast Note targets small, trusted networks where a quick shared scratch pad is useful.

--- a/fast-note/index.php
+++ b/fast-note/index.php
@@ -11,6 +11,20 @@ if (!isset($GLOBALS['db'])) {
 }
 $db = $GLOBALS['db'];
 
+// Health check endpoint
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && (($_SERVER['REQUEST_URI'] ?? '') === '/status')) {
+    $check = $db->query('SELECT 1');
+    if ($check === false) {
+        http_response_code(500);
+        header('Content-Type: text/plain');
+        echo 'error';
+    } else {
+        header('Content-Type: text/plain');
+        echo 'ok';
+    }
+    exit;
+}
+
 $id = $_GET['note'] ?? 'home';
 if (!preg_match('/^[A-Za-z0-9_-]+$/', $id)) {
     http_response_code(400);

--- a/fast-note/tests/status.php
+++ b/fast-note/tests/status.php
@@ -1,0 +1,9 @@
+<?php
+$cmd = 'FASTNOTE_DB=:memory: REQUEST_METHOD=GET REQUEST_URI=/status php ' . escapeshellarg(__DIR__ . '/../index.php');
+$out = shell_exec($cmd);
+
+if (trim($out) !== 'ok') {
+    throw new Exception('status not ok');
+}
+
+echo "status test passed\n";


### PR DESCRIPTION
## Summary
- add GET /status health endpoint that checks database connection
- document status endpoint
- add test for status endpoint

## Testing
- `php tests/basic.php && php tests/status.php`


------
https://chatgpt.com/codex/tasks/task_e_68bcfa73c2bc83239c635f614c867529