### PR TITLE
Ensure /status is handled by Apache

### DIFF
--- a/fast-note/Dockerfile
+++ b/fast-note/Dockerfile
@@ -4,6 +4,7 @@ COPY . /var/www/html
 RUN chown -R www-data:www-data /var/www/html
 RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 RUN sed -i 's/:80>/:8080>/' /etc/apache2/sites-available/000-default.conf
+RUN sed -i '/DocumentRoot \/var\/www\/html/a\\    FallbackResource /index.php' /etc/apache2/sites-available/000-default.conf
 # Create data directory for SQLite database
 RUN mkdir -p /var/www/html/data && chown www-data:www-data /var/www/html/data
 ENV FASTNOTE_DB=/var/www/html/data/notes.sqlite

--- a/fast-note/index.php
+++ b/fast-note/index.php
@@ -11,8 +11,11 @@ if (!isset($GLOBALS['db'])) {
 }
 $db = $GLOBALS['db'];
 
+$uri = $_SERVER['REQUEST_URI'] ?? '/';
+$path = parse_url($uri, PHP_URL_PATH);
+
 // Health check endpoint
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && (($_SERVER['REQUEST_URI'] ?? '') === '/status')) {
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && $path === '/status') {
     $check = $db->query('SELECT 1');
     if ($check === false) {
         http_response_code(500);
@@ -22,6 +25,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && (($_SERVER['REQUEST_URI'] ?? '') ===
         header('Content-Type: text/plain');
         echo 'ok';
     }
+    exit;
+}
+
+if ($path !== '/') {
+    http_response_code(404);
+    header('Content-Type: text/plain');
+    echo 'Not Found';
     exit;
 }
 

--- a/fast-note/tests/404.php
+++ b/fast-note/tests/404.php
@@ -1,0 +1,7 @@
+<?php
+$cmd = 'FASTNOTE_DB=:memory: REQUEST_METHOD=GET REQUEST_URI=/unknown php ' . escapeshellarg(__DIR__ . '/../index.php');
+$out = shell_exec($cmd);
+if (trim($out) !== 'Not Found') {
+    throw new Exception('expected 404 for unknown path');
+}
+echo "404 test passed\n";


### PR DESCRIPTION
## Summary
- Route all unknown paths through `index.php` so `/status` resolves correctly

## Testing
- `php tests/basic.php`
- `php tests/status.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd8de46d2c8323b749b23212bfbcff