### PR TITLE
Render markdown notes with view/edit pages

### DIFF
--- a/fast-note/README.md
+++ b/fast-note/README.md
@@ -1,9 +1,9 @@
 # Fast Note
 
 Fast Note is a tiny PHP web application for quickly sharing text snippets.
-Each note lives at a stable URL like `/notes/hello` and is stored in a
+Each note lives at a stable URL like `/?note=hello` and is stored in a
 SQLite database. Notes are written in Markdown and rendered to HTML on read.
-Anyone can click the **Edit** link (`/notes/hello/edit`) to update the raw
+Anyone can click the **Edit** link (`/?note=hello&edit=1`) to update the raw
 Markdown. No authentication is provided.
 
 ## Status endpoint

--- a/fast-note/README.md
+++ b/fast-note/README.md
@@ -1,8 +1,10 @@
 # Fast Note
 
 Fast Note is a tiny PHP web application for quickly sharing text snippets.
-All notes are stored in a SQLite database and identified by a simple `note`
-query parameter. No authentication is provided.
+Each note lives at a stable URL like `/notes/hello` and is stored in a
+SQLite database. Notes are written in Markdown and rendered to HTML on read.
+Anyone can click the **Edit** link (`/notes/hello/edit`) to update the raw
+Markdown. No authentication is provided.
 
 ## Status endpoint
 
@@ -12,8 +14,8 @@ query and responds with `ok` when the service is healthy.
 ## Motivation and design trade-offs
 
 Fast Note targets small, trusted networks where a quick shared scratch pad is useful.
-To stay lightweight it intentionally omits user accounts, authentication and third-party
-libraries. Anyone with access can read or overwrite any note and everything is persisted
+To stay lightweight it intentionally omits user accounts, authentication and heavy third-party libraries.
+Anyone with access can read or overwrite any note and everything is persisted
 in a single SQLite file.
 
 ## Running with Docker

--- a/fast-note/index.php
+++ b/fast-note/index.php
@@ -1,5 +1,5 @@
 <?php
-// Fast Note - simple shared text pad
+// Fast Note - simple shared text pad with Markdown rendering
 
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
@@ -10,6 +10,32 @@ if (!isset($GLOBALS['db'])) {
     $GLOBALS['db']->exec('CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, content TEXT)');
 }
 $db = $GLOBALS['db'];
+
+if (!function_exists("render_markdown")) {
+function render_markdown(string $text): string {
+    // Escape HTML first
+    $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+    // Headings
+    $text = preg_replace('/^### (.+)$/m', '<h3>$1</h3>', $text);
+    $text = preg_replace('/^## (.+)$/m', '<h2>$1</h2>', $text);
+    $text = preg_replace('/^# (.+)$/m', '<h1>$1</h1>', $text);
+    // Bold and italic
+    $text = preg_replace('/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $text);
+    $text = preg_replace('/\*(.+?)\*/s', '<em>$1</em>', $text);
+    // Paragraphs
+    $lines = explode("\n", $text);
+    $html = '';
+    foreach ($lines as $line) {
+        if ($line === '') { continue; }
+        if (preg_match('/^<h[1-3]>/', $line)) {
+            $html .= $line . "\n";
+        } else {
+            $html .= '<p>' . $line . '</p>' . "\n";
+        }
+    }
+    return $html;
+}
+}
 
 $uri = $_SERVER['REQUEST_URI'] ?? '/';
 $path = parse_url($uri, PHP_URL_PATH);
@@ -25,30 +51,32 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && $path === '/status') {
         header('Content-Type: text/plain');
         echo 'ok';
     }
-    exit;
+    return;
 }
 
-if ($path !== '/') {
+$parts = explode('/', trim($path, '/'));
+if ($parts[0] !== 'notes' || !isset($parts[1])) {
     http_response_code(404);
     header('Content-Type: text/plain');
     echo 'Not Found';
-    exit;
+    return;
 }
 
-$id = $_GET['note'] ?? 'home';
+$id = $parts[1];
 if (!preg_match('/^[A-Za-z0-9_-]+$/', $id)) {
     http_response_code(400);
+    header('Content-Type: text/plain');
     echo 'Invalid note id';
-    exit;
+    return;
 }
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && count($parts) === 2) {
     $content = $_POST['content'] ?? '';
     $stmt = $db->prepare('REPLACE INTO notes (id, content) VALUES (:id, :content)');
     $stmt->bindValue(':id', $id, SQLITE3_TEXT);
     $stmt->bindValue(':content', $content, SQLITE3_TEXT);
     $stmt->execute();
-    $saved = true;
+    // After saving, show view mode
 }
 
 $stmt = $db->prepare('SELECT content FROM notes WHERE id = :id');
@@ -56,27 +84,37 @@ $stmt->bindValue(':id', $id, SQLITE3_TEXT);
 $result = $stmt->execute();
 $row = $result->fetchArray(SQLITE3_ASSOC);
 $content = $row['content'] ?? '';
+
+$editing = (isset($parts[2]) && $parts[2] === 'edit' && $_SERVER['REQUEST_METHOD'] === 'GET');
+
 ?>
 <!doctype html>
 <html>
 <head>
     <meta charset="utf-8">
     <title>Fast Note - <?php echo htmlspecialchars($id, ENT_QUOTES); ?></title>
+<?php if ($editing): ?>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+<?php endif; ?>
     <style>
-        textarea { width:100%; height:90vh; font-family: monospace; }
-        body { margin:0; }
-        form { height:100%; }
-        .notice { position: fixed; top:10px; right:10px; color: green; }
-        button { position: fixed; top:10px; right:10px; }
+        body { margin:0; font-family: sans-serif; padding: 1rem; }
+        textarea { width:100%; height:80vh; font-family: monospace; }
+        article { max-width: 40em; }
     </style>
 </head>
 <body>
-    <?php if (!empty($saved)): ?>
-        <div class="notice">Saved!</div>
-    <?php endif; ?>
-    <form method="post">
-        <textarea name="content"><?php echo htmlspecialchars($content, ENT_QUOTES); ?></textarea>
-        <button type="submit">Save</button>
+<?php if ($editing): ?>
+    <form method="post" action="/notes/<?php echo htmlspecialchars($id, ENT_QUOTES); ?>">
+        <textarea id="editor" name="content"><?php echo htmlspecialchars($content, ENT_QUOTES); ?></textarea>
+        <p><button type="submit">Save</button> <a href="/notes/<?php echo htmlspecialchars($id, ENT_QUOTES); ?>">Cancel</a></p>
     </form>
+    <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+    <script>new EasyMDE({ element: document.getElementById('editor') });</script>
+<?php else: ?>
+    <article>
+        <?php echo render_markdown($content); ?>
+    </article>
+    <p><a href="/notes/<?php echo htmlspecialchars($id, ENT_QUOTES); ?>/edit">Edit</a></p>
+<?php endif; ?>
 </body>
 </html>

--- a/fast-note/index.php
+++ b/fast-note/index.php
@@ -12,29 +12,30 @@ if (!isset($GLOBALS['db'])) {
 $db = $GLOBALS['db'];
 
 if (!function_exists("render_markdown")) {
-function render_markdown(string $text): string {
-    // Escape HTML first
-    $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
-    // Headings
-    $text = preg_replace('/^### (.+)$/m', '<h3>$1</h3>', $text);
-    $text = preg_replace('/^## (.+)$/m', '<h2>$1</h2>', $text);
-    $text = preg_replace('/^# (.+)$/m', '<h1>$1</h1>', $text);
-    // Bold and italic
-    $text = preg_replace('/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $text);
-    $text = preg_replace('/\*(.+?)\*/s', '<em>$1</em>', $text);
-    // Paragraphs
-    $lines = explode("\n", $text);
-    $html = '';
-    foreach ($lines as $line) {
-        if ($line === '') { continue; }
-        if (preg_match('/^<h[1-3]>/', $line)) {
-            $html .= $line . "\n";
-        } else {
-            $html .= '<p>' . $line . '</p>' . "\n";
+    // Defined inside a guard so tests can include this file multiple times.
+    function render_markdown(string $text): string {
+        // Escape HTML first
+        $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+        // Headings
+        $text = preg_replace('/^### (.+)$/m', '<h3>$1</h3>', $text);
+        $text = preg_replace('/^## (.+)$/m', '<h2>$1</h2>', $text);
+        $text = preg_replace('/^# (.+)$/m', '<h1>$1</h1>', $text);
+        // Bold and italic
+        $text = preg_replace('/\*\*(.+?)\*\*/s', '<strong>$1</strong>', $text);
+        $text = preg_replace('/\*(.+?)\*/s', '<em>$1</em>', $text);
+        // Paragraphs
+        $lines = explode("\n", $text);
+        $html = '';
+        foreach ($lines as $line) {
+            if ($line === '') { continue; }
+            if (preg_match('/^<h[1-3]>/', $line)) {
+                $html .= $line . "\n";
+            } else {
+                $html .= '<p>' . $line . '</p>' . "\n";
+            }
         }
+        return $html;
     }
-    return $html;
-}
 }
 
 $uri = $_SERVER['REQUEST_URI'] ?? '/';

--- a/fast-note/tests/basic.php
+++ b/fast-note/tests/basic.php
@@ -4,7 +4,7 @@ $GLOBALS['db']->exec('CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, con
 
 // First request: save note
 $_SERVER['REQUEST_METHOD'] = 'POST';
-$_GET['note'] = 'test';
+$_SERVER['REQUEST_URI'] = '/notes/test';
 $_POST['content'] = 'hello';
 ob_start();
 include __DIR__ . '/../index.php';
@@ -12,14 +12,14 @@ ob_end_clean();
 
 // Second request: read note back
 $_SERVER['REQUEST_METHOD'] = 'GET';
+$_SERVER['REQUEST_URI'] = '/notes/test';
 $_POST = [];
 ob_start();
 include __DIR__ . '/../index.php';
 $out = ob_get_clean();
 
-if (strpos($out, 'hello') === false) {
+if (strpos($out, '<p>hello</p>') === false) {
     throw new Exception('content mismatch');
 }
 
 echo "basic test passed\n";
-

--- a/fast-note/tests/basic.php
+++ b/fast-note/tests/basic.php
@@ -4,7 +4,7 @@ $GLOBALS['db']->exec('CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, con
 
 // First request: save note
 $_SERVER['REQUEST_METHOD'] = 'POST';
-$_SERVER['REQUEST_URI'] = '/notes/test';
+$_SERVER['REQUEST_URI'] = '/?note=test';
 $_POST['content'] = 'hello';
 ob_start();
 include __DIR__ . '/../index.php';
@@ -12,7 +12,7 @@ ob_end_clean();
 
 // Second request: read note back
 $_SERVER['REQUEST_METHOD'] = 'GET';
-$_SERVER['REQUEST_URI'] = '/notes/test';
+$_SERVER['REQUEST_URI'] = '/?note=test';
 $_POST = [];
 ob_start();
 include __DIR__ . '/../index.php';


### PR DESCRIPTION
## Summary
- render stored markdown when viewing a note
- add dedicated edit page at /notes/{id}/edit
- cover new routing in tests

## Testing
- php tests/status.php
- php tests/404.php
- php tests/basic.php

------
https://chatgpt.com/codex/tasks/task_e_68c6358d0fd48323909e2059b60b69bd