### PR TITLE
Add minimal Rock Paper Scissors tracker app

### DIFF
--- a/.github/workflows/rps.yml
+++ b/.github/workflows/rps.yml
@@ -1,0 +1,45 @@
+name: rps
+
+on:
+  push:
+    paths:
+      - 'rps/**'
+  pull_request:
+    paths:
+      - 'rps/**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: |
+          php -l rps/index.php
+
+  build:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set build vars
+        id: vars
+        run: |
+          echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Build image
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/rps:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha }} rps
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker push ghcr.io/${{ github.repository_owner }}/rps:${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha }}

--- a/rps/Dockerfile
+++ b/rps/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.3-apache
+WORKDIR /var/www/html
+COPY . /var/www/html
+RUN chown -R www-data:www-data /var/www/html
+RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
+RUN sed -i 's/:80>/:8080>/' /etc/apache2/sites-available/000-default.conf
+RUN sed -i '/DocumentRoot \/var\/www\/html/a\\    FallbackResource /index.php' /etc/apache2/sites-available/000-default.conf
+RUN mkdir -p /var/www/html/data && chown www-data:www-data /var/www/html/data
+ENV RPS_DB=/var/www/html/data/rps.sqlite
+EXPOSE 8080

--- a/rps/README.md
+++ b/rps/README.md
@@ -1,0 +1,71 @@
+# Rock Paper Scissors Tracker
+
+## Requirements
+- Create a new minimal PHP application under `rps/` modeled after `fast-note/` with a single entry point (`index.php`).
+- Present a barebones HTML page that captures the next Rock–Paper–Scissors match between two players.
+- Persist all application data in SQLite, defaulting to `rps/data/rps.sqlite` with support for overriding the database location via an environment variable.
+- Use a relational model with dedicated `players` and `venues` tables; every match must reference exactly two players and exactly one venue by foreign key.
+- Allow players and venues to be created on the fly when entering a match result from the form.
+- Expose a lightweight `/status` endpoint that verifies database connectivity.
+- Ship a Dockerfile as part of the initial version so the app can be containerized easily.
+- Document setup and usage details in this README.
+
+## Implementation plan
+1. **Project skeleton**
+   - Add `index.php` and keep all runtime logic inside it for simplicity. Create a `data/` directory at runtime if needed and ensure the SQLite path can be overridden with an `RPS_DB` environment variable.
+   - Route only `/` and `/status`, responding with 404 for other paths to mirror fast-note's minimalism.
+
+2. **Database bootstrap**
+   - When establishing the SQLite connection, create tables if they do not exist:
+     - `players (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE COLLATE NOCASE, created_at TEXT DEFAULT CURRENT_TIMESTAMP)`
+     - `venues (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE COLLATE NOCASE, created_at TEXT DEFAULT CURRENT_TIMESTAMP)`
+     - `matches (id INTEGER PRIMARY KEY AUTOINCREMENT, played_at TEXT DEFAULT CURRENT_TIMESTAMP, player_one_id INTEGER NOT NULL, player_two_id INTEGER NOT NULL, venue_id INTEGER NOT NULL, move_one TEXT NOT NULL, move_two TEXT NOT NULL, outcome TEXT NOT NULL, FOREIGN KEY references, CHECK(player_one_id <> player_two_id))`
+   - Encapsulate connection and migration logic in helper functions so `/status` and the main handler share it.
+
+3. **Form flow & validation**
+   - Render a single HTML page with inputs for Player 1, Player 2, and Venue using `<input list>` elements backed by `<datalist>` options sourced from existing database rows to facilitate reuse.
+   - Include dropdowns for each player's move (`rock`, `paper`, `scissors`). On form submission, trim inputs, ensure moves are valid, confirm both player names are present and not identical (case-insensitive), and require a venue name.
+   - For each submitted name, attempt a case-insensitive lookup; insert the row when it does not exist, and reuse the ID if it does. Compute the outcome (`player_one`, `player_two`, or `draw`) server-side and insert the match referencing the resolved IDs.
+   - Show success or validation messages and preserve form inputs on errors. After a successful save, display the most recent 10 matches in a simple table joined to player and venue names.
+
+4. **Status endpoint**
+   - Implement `/status` to run a trivial query (e.g., `SELECT 1`) and return `ok` or a 500 response if the query fails, enabling operational checks.
+
+5. **Docker support**
+   - Create `rps/Dockerfile` based on the fast-note image: use Apache with PHP + SQLite extension, copy the app, set permissions, expose port 8080, and set `ENV RPS_DB=/var/www/html/data/rps.sqlite`.
+   - Document Docker build/run commands in the README alongside instructions for running with PHP's built-in server.
+
+## Usage
+
+### Run with PHP's built-in server
+```bash
+cd rps
+php -S localhost:8000
+```
+
+Then open <http://localhost:8000> in a browser to log matches. The application stores data in `data/rps.sqlite` by default and will create the directory/file automatically.
+
+### Status endpoint
+A lightweight health check is available at `/status`. When the database can be reached it responds with plain text `ok`.
+
+### Configuration
+Override the database location by setting the `RPS_DB` environment variable before starting PHP:
+
+```bash
+RPS_DB="file:memdb1?mode=memory&cache=shared" php -S localhost:8000
+```
+
+This is useful for ephemeral or test environments.
+
+### Run with Docker
+```bash
+cd rps
+# Build image
+docker build -t rps-tracker .
+
+# Run container with persistent storage
+mkdir -p data
+docker run -p 8080:8080 -v "$(pwd)/data:/var/www/html/data" --name rps-tracker rps-tracker
+```
+
+The Docker image exposes the service on port 8080 and persists the SQLite database via the mounted volume.

--- a/rps/index.php
+++ b/rps/index.php
@@ -1,0 +1,429 @@
+<?php
+ini_set('display_errors', '1');
+error_reporting(E_ALL);
+
+const RPS_ALLOWED_MOVES = ['rock', 'paper', 'scissors'];
+
+function rps_db_path(): string
+{
+    $envPath = getenv('RPS_DB');
+    if ($envPath && trim($envPath) !== '') {
+        return $envPath;
+    }
+    return __DIR__ . '/data/rps.sqlite';
+}
+
+function rps_db(): SQLite3
+{
+    if (!isset($GLOBALS['rps_db'])) {
+        $path = rps_db_path();
+        if (strpos($path, 'file:') !== 0 && strpos($path, ':memory:') !== 0) {
+            $dir = dirname($path);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
+        }
+
+        $GLOBALS['rps_db'] = new SQLite3($path);
+        $GLOBALS['rps_db']->exec('PRAGMA foreign_keys = ON');
+        rps_ensure_schema($GLOBALS['rps_db']);
+    }
+
+    return $GLOBALS['rps_db'];
+}
+
+function rps_ensure_schema(SQLite3 $db): void
+{
+    $db->exec('CREATE TABLE IF NOT EXISTS players (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE COLLATE NOCASE,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $db->exec('CREATE TABLE IF NOT EXISTS venues (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT UNIQUE COLLATE NOCASE,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    )');
+
+    $db->exec('CREATE TABLE IF NOT EXISTS matches (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        played_at TEXT DEFAULT CURRENT_TIMESTAMP,
+        player_one_id INTEGER NOT NULL,
+        player_two_id INTEGER NOT NULL,
+        venue_id INTEGER NOT NULL,
+        move_one TEXT NOT NULL,
+        move_two TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        FOREIGN KEY(player_one_id) REFERENCES players(id) ON DELETE RESTRICT,
+        FOREIGN KEY(player_two_id) REFERENCES players(id) ON DELETE RESTRICT,
+        FOREIGN KEY(venue_id) REFERENCES venues(id) ON DELETE RESTRICT,
+        CHECK(player_one_id <> player_two_id)
+    )');
+}
+
+function rps_status(): void
+{
+    $db = rps_db();
+    $check = $db->query('SELECT 1');
+    if ($check === false) {
+        http_response_code(500);
+        header('Content-Type: text/plain');
+        echo 'error';
+    } else {
+        header('Content-Type: text/plain');
+        echo 'ok';
+    }
+    exit;
+}
+
+function rps_find_or_create_player(SQLite3 $db, string $name): int
+{
+    $stmt = $db->prepare('SELECT id FROM players WHERE name = :name COLLATE NOCASE');
+    $stmt->bindValue(':name', $name, SQLITE3_TEXT);
+    $result = $stmt->execute();
+    $row = $result->fetchArray(SQLITE3_ASSOC);
+    if ($row && isset($row['id'])) {
+        return (int)$row['id'];
+    }
+
+    $insert = $db->prepare('INSERT INTO players (name) VALUES (:name)');
+    $insert->bindValue(':name', $name, SQLITE3_TEXT);
+    $insert->execute();
+    return (int)$db->lastInsertRowID();
+}
+
+function rps_find_or_create_venue(SQLite3 $db, string $name): int
+{
+    $stmt = $db->prepare('SELECT id FROM venues WHERE name = :name COLLATE NOCASE');
+    $stmt->bindValue(':name', $name, SQLITE3_TEXT);
+    $result = $stmt->execute();
+    $row = $result->fetchArray(SQLITE3_ASSOC);
+    if ($row && isset($row['id'])) {
+        return (int)$row['id'];
+    }
+
+    $insert = $db->prepare('INSERT INTO venues (name) VALUES (:name)');
+    $insert->bindValue(':name', $name, SQLITE3_TEXT);
+    $insert->execute();
+    return (int)$db->lastInsertRowID();
+}
+
+function rps_determine_outcome(string $moveOne, string $moveTwo): string
+{
+    if ($moveOne === $moveTwo) {
+        return 'draw';
+    }
+
+    $beats = [
+        'rock' => 'scissors',
+        'paper' => 'rock',
+        'scissors' => 'paper',
+    ];
+
+    if ($beats[$moveOne] === $moveTwo) {
+        return 'player_one';
+    }
+
+    return 'player_two';
+}
+
+function rps_recent_matches(SQLite3 $db): array
+{
+    $query = $db->prepare('SELECT m.played_at, p1.name AS player_one, p2.name AS player_two, v.name AS venue, m.move_one, m.move_two, m.outcome
+        FROM matches m
+        JOIN players p1 ON m.player_one_id = p1.id
+        JOIN players p2 ON m.player_two_id = p2.id
+        JOIN venues v ON m.venue_id = v.id
+        ORDER BY m.played_at DESC, m.id DESC
+        LIMIT 10');
+    $result = $query->execute();
+
+    $rows = [];
+    while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+        $rows[] = $row;
+    }
+    return $rows;
+}
+
+function rps_all_names(SQLite3 $db, string $table): array
+{
+    $query = $db->prepare("SELECT name FROM {$table} ORDER BY name COLLATE NOCASE ASC");
+    $result = $query->execute();
+
+    $names = [];
+    while ($row = $result->fetchArray(SQLITE3_ASSOC)) {
+        $names[] = $row['name'];
+    }
+    return $names;
+}
+
+$uri = $_SERVER['REQUEST_URI'] ?? '/';
+$path = parse_url($uri, PHP_URL_PATH) ?: '/';
+
+if ($path === '/status') {
+    rps_status();
+}
+
+if ($path !== '/') {
+    http_response_code(404);
+    header('Content-Type: text/plain');
+    echo 'Not Found';
+    exit;
+}
+
+$db = rps_db();
+
+$form = [
+    'player_one' => '',
+    'player_two' => '',
+    'venue' => '',
+    'move_one' => RPS_ALLOWED_MOVES[0],
+    'move_two' => RPS_ALLOWED_MOVES[0],
+];
+$errors = [];
+$saved = false;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $form['player_one'] = trim($_POST['player_one'] ?? '');
+    $form['player_two'] = trim($_POST['player_two'] ?? '');
+    $form['venue'] = trim($_POST['venue'] ?? '');
+    $form['move_one'] = $_POST['move_one'] ?? RPS_ALLOWED_MOVES[0];
+    $form['move_two'] = $_POST['move_two'] ?? RPS_ALLOWED_MOVES[0];
+
+    if ($form['player_one'] === '') {
+        $errors[] = 'Player 1 name is required.';
+    }
+    if ($form['player_two'] === '') {
+        $errors[] = 'Player 2 name is required.';
+    }
+    if ($form['player_one'] !== '' && $form['player_two'] !== '' && strcasecmp($form['player_one'], $form['player_two']) === 0) {
+        $errors[] = 'Players must be different people.';
+    }
+    if ($form['venue'] === '') {
+        $errors[] = 'Venue name is required.';
+    }
+    if (!in_array($form['move_one'], RPS_ALLOWED_MOVES, true)) {
+        $errors[] = 'Invalid move for Player 1.';
+    }
+    if (!in_array($form['move_two'], RPS_ALLOWED_MOVES, true)) {
+        $errors[] = 'Invalid move for Player 2.';
+    }
+
+    if (empty($errors)) {
+        $db->exec('BEGIN');
+        try {
+            $playerOneId = rps_find_or_create_player($db, $form['player_one']);
+            $playerTwoId = rps_find_or_create_player($db, $form['player_two']);
+            $venueId = rps_find_or_create_venue($db, $form['venue']);
+            if ($playerOneId === $playerTwoId) {
+                throw new RuntimeException('Players must be different.');
+            }
+
+            $outcome = rps_determine_outcome($form['move_one'], $form['move_two']);
+            $insert = $db->prepare('INSERT INTO matches (player_one_id, player_two_id, venue_id, move_one, move_two, outcome) VALUES (:p1, :p2, :venue, :move_one, :move_two, :outcome)');
+            $insert->bindValue(':p1', $playerOneId, SQLITE3_INTEGER);
+            $insert->bindValue(':p2', $playerTwoId, SQLITE3_INTEGER);
+            $insert->bindValue(':venue', $venueId, SQLITE3_INTEGER);
+            $insert->bindValue(':move_one', $form['move_one'], SQLITE3_TEXT);
+            $insert->bindValue(':move_two', $form['move_two'], SQLITE3_TEXT);
+            $insert->bindValue(':outcome', $outcome, SQLITE3_TEXT);
+            $insert->execute();
+
+            $db->exec('COMMIT');
+            $saved = true;
+            $form = [
+                'player_one' => '',
+                'player_two' => '',
+                'venue' => '',
+                'move_one' => RPS_ALLOWED_MOVES[0],
+                'move_two' => RPS_ALLOWED_MOVES[0],
+            ];
+        } catch (Throwable $e) {
+            $db->exec('ROLLBACK');
+            $errors[] = 'Failed to save match: ' . $e->getMessage();
+        }
+    }
+}
+
+$players = rps_all_names($db, 'players');
+$venues = rps_all_names($db, 'venues');
+$matches = rps_recent_matches($db);
+
+function rps_escape(string $value): string
+{
+    return htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+}
+
+function rps_outcome_label(string $outcome): string
+{
+    switch ($outcome) {
+        case 'player_one':
+            return 'Player 1';
+        case 'player_two':
+            return 'Player 2';
+        default:
+            return 'Draw';
+    }
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Rock Paper Scissors Tracker</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f9f9f9;
+        }
+        h1 {
+            font-size: 1.8rem;
+            margin-bottom: 0.5rem;
+        }
+        form {
+            background: #fff;
+            padding: 16px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            margin-bottom: 24px;
+        }
+        label {
+            display: block;
+            font-weight: bold;
+            margin-bottom: 4px;
+        }
+        input[type="text"], select {
+            width: 100%;
+            padding: 8px;
+            margin-bottom: 12px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+        }
+        button {
+            padding: 10px 16px;
+            border: none;
+            background: #333;
+            color: #fff;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .notice {
+            margin-bottom: 12px;
+            padding: 10px;
+            border-radius: 4px;
+        }
+        .success {
+            background: #e0f6e9;
+            color: #1a7f3b;
+        }
+        .errors {
+            background: #fdecea;
+            color: #c0392b;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+        }
+        th, td {
+            padding: 8px;
+            border: 1px solid #ddd;
+            text-align: left;
+        }
+        th {
+            background: #f0f0f0;
+        }
+    </style>
+</head>
+<body>
+    <h1>Rock Paper Scissors Tracker</h1>
+    <p>Log the next match result between two players. All entries are stored in SQLite.</p>
+
+    <?php if (!empty($errors)): ?>
+        <div class="notice errors">
+            <ul>
+                <?php foreach ($errors as $error): ?>
+                    <li><?php echo rps_escape($error); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php elseif ($saved): ?>
+        <div class="notice success">Match recorded!</div>
+    <?php endif; ?>
+
+    <form method="post">
+        <label for="player_one">Player 1</label>
+        <input type="text" name="player_one" id="player_one" list="players" value="<?php echo rps_escape($form['player_one']); ?>" autocomplete="off" required>
+
+        <label for="move_one">Player 1 move</label>
+        <select name="move_one" id="move_one">
+            <?php foreach (RPS_ALLOWED_MOVES as $move): ?>
+                <option value="<?php echo rps_escape($move); ?>" <?php echo $form['move_one'] === $move ? 'selected' : ''; ?>><?php echo ucfirst($move); ?></option>
+            <?php endforeach; ?>
+        </select>
+
+        <label for="player_two">Player 2</label>
+        <input type="text" name="player_two" id="player_two" list="players" value="<?php echo rps_escape($form['player_two']); ?>" autocomplete="off" required>
+
+        <label for="move_two">Player 2 move</label>
+        <select name="move_two" id="move_two">
+            <?php foreach (RPS_ALLOWED_MOVES as $move): ?>
+                <option value="<?php echo rps_escape($move); ?>" <?php echo $form['move_two'] === $move ? 'selected' : ''; ?>><?php echo ucfirst($move); ?></option>
+            <?php endforeach; ?>
+        </select>
+
+        <label for="venue">Venue</label>
+        <input type="text" name="venue" id="venue" list="venues" value="<?php echo rps_escape($form['venue']); ?>" autocomplete="off" required>
+
+        <button type="submit">Record match</button>
+    </form>
+
+    <datalist id="players">
+        <?php foreach ($players as $player): ?>
+            <option value="<?php echo rps_escape($player); ?>"></option>
+        <?php endforeach; ?>
+    </datalist>
+
+    <datalist id="venues">
+        <?php foreach ($venues as $venue): ?>
+            <option value="<?php echo rps_escape($venue); ?>"></option>
+        <?php endforeach; ?>
+    </datalist>
+
+    <h2>Recent matches</h2>
+    <?php if (empty($matches)): ?>
+        <p>No matches recorded yet.</p>
+    <?php else: ?>
+        <table>
+            <thead>
+                <tr>
+                    <th>Played at</th>
+                    <th>Player 1</th>
+                    <th>Move</th>
+                    <th>Player 2</th>
+                    <th>Move</th>
+                    <th>Venue</th>
+                    <th>Winner</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($matches as $match): ?>
+                    <tr>
+                        <td><?php echo rps_escape($match['played_at']); ?></td>
+                        <td><?php echo rps_escape($match['player_one']); ?></td>
+                        <td><?php echo rps_escape(ucfirst($match['move_one'])); ?></td>
+                        <td><?php echo rps_escape($match['player_two']); ?></td>
+                        <td><?php echo rps_escape(ucfirst($match['move_two'])); ?></td>
+                        <td><?php echo rps_escape($match['venue']); ?></td>
+                        <td><?php echo rps_escape(rps_outcome_label($match['outcome'])); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    <?php endif; ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Rock Paper Scissors tracker README outlining requirements, implementation plan, and usage details
- implement the PHP entrypoint with relational schema bootstrapping, form handling, and recent match display
- provide a Dockerfile to run the tracker under Apache with SQLite persistence

## Testing
- php -l rps/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ca2842ff988323b287eebb1bea6984