### PR TITLE
Add HTTP Rocket Svelte+TypeScript scaffold and multi-stage Dockerfile

### DIFF
--- a/http-rocket/Dockerfile
+++ b/http-rocket/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json tsconfig.json tsconfig.node.json vite.config.ts index.html ./
+COPY src ./src
+RUN npm install && npm run build
+
+FROM httpd:2.4-alpine
+COPY --from=build /app/dist/ /usr/local/apache2/htdocs/
+EXPOSE 80

--- a/http-rocket/README.md
+++ b/http-rocket/README.md
@@ -1,0 +1,36 @@
+# HTTP Rocket
+
+`HTTP Rocket` is a client-only web HTTP client (Svelte + TypeScript).
+
+## Selected Name
+- Project directory: `http-rocket`
+- Planned image name: `ghcr.io/tphummel/http-rocket`
+
+## Current Status
+Initial scaffold is now in place:
+- Svelte + TypeScript + Vite app skeleton
+- Apache httpd production image via multi-stage Dockerfile
+
+## Planned Features
+- Request builder (URL, verb, headers)
+- Save/send behavior with browser persistence
+- Multiple named request configurations in local storage
+- Import/export JSON configuration
+- Audit tab with last 1000 request/response records
+
+## Local Development
+```bash
+npm install
+npm run dev
+```
+
+## Build
+```bash
+npm run build
+```
+
+## Container
+```bash
+docker build -t http-rocket .
+docker run --rm -p 8080:80 http-rocket
+```

--- a/http-rocket/index.html
+++ b/http-rocket/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HTTP Rocket</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/http-rocket/notes.md
+++ b/http-rocket/notes.md
@@ -1,0 +1,14 @@
+# Notes
+
+- Created new project folder `http-client-web` per repo AGENTS instructions.
+- Need to inspect existing CI workflow patterns for GHCR publish on changes to a specific subdir on `main`.
+- Collected initial requirements from user: client-only HTTP tool, local storage config import/export, request builder, send/save behavior, audit log for last 1000 requests with response details.
+- Reviewed existing workflows `.github/workflows/fast-note.yml` and `.github/workflows/jigseer.yml` to mirror path-based build/publish triggers and image tag strategy.
+- User confirmed stack direction: Svelte + TypeScript.
+- User requested Apache/httpd runtime for smallest practical static-serving image.
+- User wants multiple named request configs persisted in browser storage.
+- Updated planning doc with concrete decisions and proposed candidate project names under ghcr.io/tphummel/<name>.
+- User selected final project name: `http-rocket`.
+- Renamed project directory from `http-client-web` to `http-rocket`.
+- Added Svelte + TypeScript + Vite scaffold files.
+- Added Apache httpd multi-stage Dockerfile for static asset serving.

--- a/http-rocket/package.json
+++ b/http-rocket/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "http-rocket",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --host",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.6.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/http-rocket/src/App.svelte
+++ b/http-rocket/src/App.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  const name = 'HTTP Rocket';
+</script>
+
+<main>
+  <h1>{name}</h1>
+  <p>Project scaffold created. Next step: implement request builder, saved requests, and audit log.</p>
+</main>
+
+<style>
+  main {
+    font-family: system-ui, sans-serif;
+    margin: 2rem auto;
+    max-width: 60rem;
+    padding: 0 1rem;
+  }
+</style>

--- a/http-rocket/src/main.ts
+++ b/http-rocket/src/main.ts
@@ -1,0 +1,7 @@
+import App from './App.svelte';
+
+const app = new App({
+  target: document.getElementById('app')!
+});
+
+export default app;

--- a/http-rocket/tsconfig.json
+++ b/http-rocket/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
+}

--- a/http-rocket/tsconfig.node.json
+++ b/http-rocket/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/http-rocket/vite.config.ts
+++ b/http-rocket/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()]
+});


### PR DESCRIPTION
### Motivation
- Introduce a new client-only HTTP tool project scaffold (Svelte + TypeScript + Vite) to implement a request builder, saved requests, and an audit log. 
- Provide a small, reproducible production image that serves the built static site via Apache httpd. 
- Capture initial project planning, requirements, and local development/build instructions in repo docs.

### Description
- Add a new `http-rocket` app skeleton including `src/App.svelte`, `src/main.ts`, `index.html`, and Vite/Svelte configuration in `vite.config.ts` and `tsconfig` files. 
- Add `package.json` with development scripts (`dev`, `build`, `preview`, `check`) and Svelte/Vite/TypeScript devDependencies. 
- Add a multi-stage `Dockerfile` that builds the app with `node:22-alpine` and copies the `dist/` output into an `httpd:2.4-alpine` runtime, exposing port `80`. 
- Add project documentation and notes via `README.md` and `notes.md` describing status, planned features, and local/container build commands. 

### Testing
- No automated tests were added or executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a080d79efb08323be19b457615cb9c8)